### PR TITLE
Handle enabled log driver list with spaces in it

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -26,7 +26,10 @@ function loadConfigSync(opts) {
     // make sure that no driver was specified that doesn't actually exist.
     if (config.enabledLogDrivers) {
         assert.string(config.enabledLogDrivers, 'config.enabledLogDrivers-raw');
-        config.enabledLogDrivers = config.enabledLogDrivers.split(',');
+        config.enabledLogDrivers = config.enabledLogDrivers.split(',')
+            .map(function (driver) {
+                return driver.trim();
+            });
     } else {
         config.enabledLogDrivers = ['json-file'];
     }


### PR DESCRIPTION
Enabled log driver list with any spaces in it would break driver validation.